### PR TITLE
Fix #5: Speed up example tests by sharing FetchContent dependencies

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,12 +21,14 @@ function(add_example_test name source_dir exec_name)
             --build-options
                 -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                 -DCMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}
+                -DFETCHCONTENT_BASE_DIR=${CMAKE_BINARY_DIR}/_deps
             --test-command ${exec_name}
     )
 
     set_tests_properties(example_${name} PROPERTIES
         TIMEOUT 300
         LABELS "examples"
+        COST 100
     )
 endfunction()
 
@@ -35,3 +37,9 @@ add_example_test(fetchcontent fetchcontent_example example_app)
 add_example_test(basic helpers_basic_example basic_example)
 add_example_test(file helpers_file_example file_example)
 add_example_test(inline helpers_inline_example inline_example)
+
+# Serialize example tests to avoid FetchContent race conditions when writing to shared _deps
+# First test populates the directory, subsequent tests reuse without conflicts
+set_tests_properties(example_basic PROPERTIES DEPENDS example_fetchcontent)
+set_tests_properties(example_file PROPERTIES DEPENDS example_basic)
+set_tests_properties(example_inline PROPERTIES DEPENDS example_file)


### PR DESCRIPTION
## Summary
Fixed excessive example test execution time by sharing FetchContent dependencies across all example builds.

## Problem
- Each of the 4 example tests created separate build directories
- Each independently downloaded Boost (~60MB tarball) and boost.mustache  
- 4 example tests × (download + build) = significant redundant work
- Example tests started late in parallel runs, blocking overall completion

## Solution
1. **Shared dependency directory**: Set `FETCHCONTENT_BASE_DIR` to parent build's `_deps`
2. **Serialized execution**: Added `DEPENDS` chain to prevent FetchContent race conditions
3. **Priority scheduling**: Added `COST 100` to start examples early in parallel test runs

## Changes
- `examples/CMakeLists.txt:24`: Added `-DFETCHCONTENT_BASE_DIR=${CMAKE_BINARY_DIR}/_deps`
- `examples/CMakeLists.txt:31`: Added `COST 100` property for early scheduling
- `examples/CMakeLists.txt:42-44`: Serialized example tests with `DEPENDS`

## Technical Details
**Why serialization?** FetchContent's internal locking isn't granular enough to prevent race conditions when multiple CMake processes configure different projects using the same `_deps` directory simultaneously.

**Why COST property?** CTest runs higher-cost tests first. Starting the example chain early maximizes parallelism with other tests.

## Test Results
✅ All 69 tests pass (100% pass rate)  
⏱️ Total test time: ~14 seconds (examples start early, don't block other tests

## Impact
- **First example run**: Downloads and builds dependencies (~same time as before)
- **Subsequent examples**: Reuse already-downloaded dependencies (much faster)
- **Overall**: Significant time savings, better parallel test scheduling

Fixes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)