### PR TITLE
Add CMake build rules for showcase examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,38 @@ function(add_example_test name source_dir exec_name)
     )
 endfunction()
 
+# Generate showcase examples automatically
+set(SHOWCASE_OUTPUT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/generated)
+file(MAKE_DIRECTORY ${SHOWCASE_OUTPUT_DIR})
+
+add_custom_command(
+    OUTPUT ${SHOWCASE_OUTPUT_DIR}/strong_types_showcase.hpp
+    COMMAND atlas
+        --input=${CMAKE_CURRENT_SOURCE_DIR}/strong_types_showcase.txt
+        --output=${SHOWCASE_OUTPUT_DIR}/strong_types_showcase.hpp
+    DEPENDS atlas ${CMAKE_CURRENT_SOURCE_DIR}/strong_types_showcase.txt
+    COMMENT "Generating strong_types_showcase.hpp"
+    VERBATIM
+)
+
+add_custom_command(
+    OUTPUT ${SHOWCASE_OUTPUT_DIR}/interactions_showcase.hpp
+    COMMAND atlas
+        --interactions=true
+        --input=${CMAKE_CURRENT_SOURCE_DIR}/interactions_showcase.txt
+        --output=${SHOWCASE_OUTPUT_DIR}/interactions_showcase.hpp
+    DEPENDS atlas ${CMAKE_CURRENT_SOURCE_DIR}/interactions_showcase.txt
+    COMMENT "Generating interactions_showcase.hpp"
+    VERBATIM
+)
+
+add_custom_target(showcase_examples ALL
+    DEPENDS
+        ${SHOWCASE_OUTPUT_DIR}/strong_types_showcase.hpp
+        ${SHOWCASE_OUTPUT_DIR}/interactions_showcase.hpp
+    COMMENT "Building showcase examples"
+)
+
 # Add each example as a test
 add_example_test(fetchcontent fetchcontent_example example_app)
 add_example_test(basic helpers_basic_example basic_example)

--- a/examples/generated/interactions_showcase.hpp
+++ b/examples/generated/interactions_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_INTERACTIONS_596AF7B0094C2CEDD612C8738813EEE3F924CFEA
-#define EXAMPLE_INTERACTIONS_596AF7B0094C2CEDD612C8738813EEE3F924CFEA
+#ifndef EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780
+#define EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -34,12 +34,14 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto
-    operator<=>(strong_type_tag const &, strong_type_tag const &) = default;
+    friend auto operator<=>(
+        strong_type_tag const &,
+        strong_type_tag const &) = default;
 #endif
 };
 
-struct value_tag {};
+struct value_tag
+{ };
 
 namespace atlas_detail {
 
@@ -99,10 +101,7 @@ value(T & val, PriorityTag<0>)
 }
 
 template <typename T, typename U = typename T::atlas_value_type>
-using val_t = _t<std::conditional<
-    std::is_const<T>::value,
-    U const &,
-    U &>>;
+using val_t = _t<std::conditional<std::is_const<T>::value, U const &, U &>>;
 
 template <typename T, typename U = val_t<T>>
 constexpr auto
@@ -141,8 +140,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto
-    operator()(T && t) const
+    constexpr auto operator ()(T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));
@@ -179,109 +177,127 @@ value(T && t)
 // These allow atlas::value() to work with external library types
 // Users can override by providing atlas_value(T const&) without the tag parameter
 namespace atlas {
-inline auto atlas_value(::concurrency::ThreadId const& v, value_tag)
+inline auto
+atlas_value(::concurrency::ThreadId const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::data::ByteCount const& v, value_tag)
+inline constexpr auto
+atlas_value(::data::ByteCount const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::data::size_t const& v, value_tag)
+inline constexpr auto
+atlas_value(::data::size_t const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::finance::core::Money const& v, value_tag)
+inline constexpr auto
+atlas_value(::finance::core::Money const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::finance::core::double const& v, value_tag)
+inline constexpr auto
+atlas_value(::finance::core::double const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::geo::Latitude const& v, value_tag)
+inline constexpr auto
+atlas_value(::geo::Latitude const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::geo::Longitude const& v, value_tag)
+inline constexpr auto
+atlas_value(::geo::Longitude const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::geo::double const& v, value_tag)
+inline constexpr auto
+atlas_value(::geo::double const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::graphics::color::RedChannel const& v, value_tag)
+inline constexpr auto
+atlas_value(::graphics::color::RedChannel const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::math::rational::Denominator const& v, value_tag)
+inline constexpr auto
+atlas_value(::math::rational::Denominator const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::math::rational::Numerator const& v, value_tag)
+inline constexpr auto
+atlas_value(::math::rational::Numerator const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::net::ipv4::Octet const& v, value_tag)
+inline constexpr auto
+atlas_value(::net::ipv4::Octet const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::net::ipv4::int const& v, value_tag)
+inline constexpr auto
+atlas_value(::net::ipv4::int const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::physics::units::Meters const& v, value_tag)
+inline constexpr auto
+atlas_value(::physics::units::Meters const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::physics::units::MetersPerSecond const& v, value_tag)
+inline constexpr auto
+atlas_value(::physics::units::MetersPerSecond const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::physics::units::Seconds const& v, value_tag)
+inline constexpr auto
+atlas_value(::physics::units::Seconds const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::physics::units::double const& v, value_tag)
+inline constexpr auto
+atlas_value(::physics::units::double const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
 }
 
-inline constexpr auto atlas_value(::security::EncryptedData const& v, value_tag)
+inline constexpr auto
+atlas_value(::security::EncryptedData const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
@@ -296,16 +312,21 @@ inline constexpr auto atlas_value(::security::EncryptedData const& v, value_tag)
 namespace atlas {
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_modulo : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_modulo
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_modulo<L, R,
+template <typename L, typename R>
+struct has_compound_op_modulo<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) %=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_modulo(L & lhs, R const & rhs, std::true_type)
 {
@@ -313,7 +334,7 @@ compound_assign_impl_modulo(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_modulo(L & lhs, R const & rhs, std::false_type)
 {
@@ -322,31 +343,41 @@ compound_assign_impl_modulo(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator%=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_modulo(lhs, rhs,
+inline auto
+operator%=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_modulo(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_modulo<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_modulo(lhs, rhs,
+    return atlas_detail::compound_assign_impl_modulo(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_modulo<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_bitand : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_bitand
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_bitand<L, R,
+template <typename L, typename R>
+struct has_compound_op_bitand<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) &=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitand(L & lhs, R const & rhs, std::true_type)
 {
@@ -354,7 +385,7 @@ compound_assign_impl_bitand(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitand(L & lhs, R const & rhs, std::false_type)
 {
@@ -363,31 +394,41 @@ compound_assign_impl_bitand(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator&=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_bitand(lhs, rhs,
+inline auto
+operator&=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_bitand(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_bitand<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_bitand(lhs, rhs,
+    return atlas_detail::compound_assign_impl_bitand(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_bitand<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_times : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_times
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_times<L, R,
+template <typename L, typename R>
+struct has_compound_op_times<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) *=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_times(L & lhs, R const & rhs, std::true_type)
 {
@@ -395,7 +436,7 @@ compound_assign_impl_times(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_times(L & lhs, R const & rhs, std::false_type)
 {
@@ -404,31 +445,41 @@ compound_assign_impl_times(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator*=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_times(lhs, rhs,
+inline auto
+operator*=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_times(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_times<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_times(lhs, rhs,
+    return atlas_detail::compound_assign_impl_times(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_times<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_plus : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_plus
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_plus<L, R,
+template <typename L, typename R>
+struct has_compound_op_plus<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) +=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_plus(L & lhs, R const & rhs, std::true_type)
 {
@@ -436,7 +487,7 @@ compound_assign_impl_plus(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_plus(L & lhs, R const & rhs, std::false_type)
 {
@@ -445,31 +496,41 @@ compound_assign_impl_plus(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator+=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_plus(lhs, rhs,
+inline auto
+operator+=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_plus(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_plus<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_plus(lhs, rhs,
+    return atlas_detail::compound_assign_impl_plus(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_plus<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_minus : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_minus
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_minus<L, R,
+template <typename L, typename R>
+struct has_compound_op_minus<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) -=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_minus(L & lhs, R const & rhs, std::true_type)
 {
@@ -477,7 +538,7 @@ compound_assign_impl_minus(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_minus(L & lhs, R const & rhs, std::false_type)
 {
@@ -486,31 +547,41 @@ compound_assign_impl_minus(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator-=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_minus(lhs, rhs,
+inline auto
+operator-=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_minus(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_minus<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_minus(lhs, rhs,
+    return atlas_detail::compound_assign_impl_minus(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_minus<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_divide : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_divide
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_divide<L, R,
+template <typename L, typename R>
+struct has_compound_op_divide<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) /=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_divide(L & lhs, R const & rhs, std::true_type)
 {
@@ -518,7 +589,7 @@ compound_assign_impl_divide(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_divide(L & lhs, R const & rhs, std::false_type)
 {
@@ -527,31 +598,41 @@ compound_assign_impl_divide(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator/=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_divide(lhs, rhs,
+inline auto
+operator/=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_divide(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_divide<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_divide(lhs, rhs,
+    return atlas_detail::compound_assign_impl_divide(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_divide<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_lshift : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_lshift
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_lshift<L, R,
+template <typename L, typename R>
+struct has_compound_op_lshift<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) <<=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_lshift(L & lhs, R const & rhs, std::true_type)
 {
@@ -559,7 +640,7 @@ compound_assign_impl_lshift(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_lshift(L & lhs, R const & rhs, std::false_type)
 {
@@ -568,31 +649,41 @@ compound_assign_impl_lshift(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator<<=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_lshift(lhs, rhs,
+inline auto
+operator<<=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_lshift(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_lshift<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_lshift(lhs, rhs,
+    return atlas_detail::compound_assign_impl_lshift(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_lshift<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_rshift : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_rshift
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_rshift<L, R,
+template <typename L, typename R>
+struct has_compound_op_rshift<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) >>=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_rshift(L & lhs, R const & rhs, std::true_type)
 {
@@ -600,7 +691,7 @@ compound_assign_impl_rshift(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_rshift(L & lhs, R const & rhs, std::false_type)
 {
@@ -609,31 +700,41 @@ compound_assign_impl_rshift(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator>>=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_rshift(lhs, rhs,
+inline auto
+operator>>=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_rshift(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_rshift<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_rshift(lhs, rhs,
+    return atlas_detail::compound_assign_impl_rshift(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_rshift<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_bitxor : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_bitxor
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_bitxor<L, R,
+template <typename L, typename R>
+struct has_compound_op_bitxor<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) ^=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitxor(L & lhs, R const & rhs, std::true_type)
 {
@@ -641,7 +742,7 @@ compound_assign_impl_bitxor(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitxor(L & lhs, R const & rhs, std::false_type)
 {
@@ -650,31 +751,41 @@ compound_assign_impl_bitxor(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator^=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_bitxor(lhs, rhs,
+inline auto
+operator^=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_bitxor(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_bitxor<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_bitxor(lhs, rhs,
+    return atlas_detail::compound_assign_impl_bitxor(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_bitxor<L, R>{});
 }
 
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_bitor : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_bitor
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_bitor<L, R,
+template <typename L, typename R>
+struct has_compound_op_bitor<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) |=
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitor(L & lhs, R const & rhs, std::true_type)
 {
@@ -682,7 +793,7 @@ compound_assign_impl_bitor(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_bitor(L & lhs, R const & rhs, std::false_type)
 {
@@ -691,17 +802,22 @@ compound_assign_impl_bitor(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator|=(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_bitor(lhs, rhs,
+inline auto
+operator|=(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_bitor(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_bitor<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_bitor(lhs, rhs,
+    return atlas_detail::compound_assign_impl_bitor(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_bitor<L, R>{});
 }
 
@@ -1063,4 +1179,4 @@ operator+(EncryptedData lhs, EncryptedData rhs)
 
 } // namespace security
 
-#endif // EXAMPLE_INTERACTIONS_596AF7B0094C2CEDD612C8738813EEE3F924CFEA
+#endif // EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780

--- a/examples/generated/strong_types_showcase.hpp
+++ b/examples/generated/strong_types_showcase.hpp
@@ -41,12 +41,14 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto
-    operator<=>(strong_type_tag const &, strong_type_tag const &) = default;
+    friend auto operator<=>(
+        strong_type_tag const &,
+        strong_type_tag const &) = default;
 #endif
 };
 
-struct value_tag {};
+struct value_tag
+{ };
 
 namespace atlas_detail {
 
@@ -106,10 +108,7 @@ value(T & val, PriorityTag<0>)
 }
 
 template <typename T, typename U = typename T::atlas_value_type>
-using val_t = _t<std::conditional<
-    std::is_const<T>::value,
-    U const &,
-    U &>>;
+using val_t = _t<std::conditional<std::is_const<T>::value, U const &, U &>>;
 
 template <typename T, typename U = val_t<T>>
 constexpr auto
@@ -148,8 +147,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto
-    operator()(T && t) const
+    constexpr auto operator ()(T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));

--- a/src/lib/AtlasUtilities.cpp
+++ b/src/lib/AtlasUtilities.cpp
@@ -85,12 +85,14 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto
-    operator<=>(strong_type_tag const &, strong_type_tag const &) = default;
+    friend auto operator<=>(
+        strong_type_tag const &,
+        strong_type_tag const &) = default;
 #endif
 };
 
-struct value_tag {};
+struct value_tag
+{ };
 
 namespace atlas_detail {
 
@@ -150,10 +152,7 @@ value(T & val, PriorityTag<0>)
 }
 
 template <typename T, typename U = typename T::atlas_value_type>
-using val_t = _t<std::conditional<
-    std::is_const<T>::value,
-    U const &,
-    U &>>;
+using val_t = _t<std::conditional<std::is_const<T>::value, U const &, U &>>;
 
 template <typename T, typename U = val_t<T>>
 constexpr auto
@@ -192,8 +191,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto
-    operator()(T && t) const
+    constexpr auto operator ()(T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));

--- a/src/lib/InteractionGenerator.cpp
+++ b/src/lib/InteractionGenerator.cpp
@@ -26,16 +26,21 @@ namespace {
 // 2. Otherwise fall back to binary operator + assignment (creates temporary)
 static constexpr char const compound_operator_template[] = R"(
 namespace atlas_detail {
-template<typename L, typename R, typename = void>
-struct has_compound_op_{{{op_id}}} : std::false_type {};
+template <typename L, typename R, typename = void>
+struct has_compound_op_{{{op_id}}}
+: std::false_type
+{ };
 
-template<typename L, typename R>
-struct has_compound_op_{{{op_id}}}<L, R,
+template <typename L, typename R>
+struct has_compound_op_{{{op_id}}}<
+    L,
+    R,
     decltype((void)(atlas::value(std::declval<L&>()) {{{compound_op}}}
         atlas::value(std::declval<R const&>())))>
-: std::true_type {};
+: std::true_type
+{ };
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_{{{op_id}}}(L & lhs, R const & rhs, std::true_type)
 {
@@ -43,7 +48,7 @@ compound_assign_impl_{{{op_id}}}(L & lhs, R const & rhs, std::true_type)
     return lhs;
 }
 
-template<typename L, typename R>
+template <typename L, typename R>
 constexpr L &
 compound_assign_impl_{{{op_id}}}(L & lhs, R const & rhs, std::false_type)
 {
@@ -52,17 +57,22 @@ compound_assign_impl_{{{op_id}}}(L & lhs, R const & rhs, std::false_type)
 }
 }
 
-template<
+template <
     typename L,
     typename R,
     typename std::enable_if<
         std::is_base_of<atlas::strong_type_tag, L>::value,
         bool>::type = true>
-inline auto operator{{{compound_op}}}(L & lhs, R const & rhs)
--> decltype(atlas_detail::compound_assign_impl_{{{op_id}}}(lhs, rhs,
+inline auto
+operator{{{compound_op}}}(L & lhs, R const & rhs)
+-> decltype(atlas_detail::compound_assign_impl_{{{op_id}}}(
+    lhs,
+    rhs,
     atlas_detail::has_compound_op_{{{op_id}}}<L, R>{}))
 {
-    return atlas_detail::compound_assign_impl_{{{op_id}}}(lhs, rhs,
+    return atlas_detail::compound_assign_impl_{{{op_id}}}(
+        lhs,
+        rhs,
         atlas_detail::has_compound_op_{{{op_id}}}<L, R>{});
 }
 )";
@@ -77,18 +87,18 @@ generate_template_header(
     if (constraint.has_concept() && constraint.has_enable_if()) {
         // Both available - use feature detection
         oss << "#if __cpp_concepts >= 201907L\n";
-        oss << "template<" << constraint.concept_expr << " "
+        oss << "template <" << constraint.concept_expr << " "
             << template_param_name << ">\n";
         oss << "#else\n";
-        oss << "template<typename " << template_param_name << ", "
+        oss << "template <typename " << template_param_name << ", "
             << "typename std::enable_if<" << constraint.enable_if_expr
             << ", bool>::type = true>\n";
         oss << "#endif\n";
     } else if (constraint.has_concept()) {
-        oss << "template<" << constraint.concept_expr << " "
+        oss << "template <" << constraint.concept_expr << " "
             << template_param_name << ">\n";
     } else if (constraint.has_enable_if()) {
-        oss << "template<typename " << template_param_name << ", "
+        oss << "template <typename " << template_param_name << ", "
             << "typename std::enable_if<" << constraint.enable_if_expr
             << ", bool>::type = true>\n";
     } else {
@@ -323,7 +333,7 @@ namespace atlas {
             if (info.is_constexpr) {
                 body << "constexpr ";
             }
-            body << "auto atlas_value(" << rhs_type
+            body << "auto\natlas_value(" << rhs_type
                 << " const& v, value_tag)\n";
             body << "-> decltype("
                 << generate_value_access("v", info.access_expr, "") << ")\n";

--- a/tests/interaction_generator_ut.cpp
+++ b/tests/interaction_generator_ut.cpp
@@ -136,7 +136,7 @@ TEST_SUITE("InteractionGenerator")
         CHECK(contains(code, "#endif"));
 
         // Check C++20 concept version
-        CHECK(contains(code, "template<std::floating_point T>"));
+        CHECK(contains(code, "template <std::floating_point T>"));
 
         // Check C++11 SFINAE version
         CHECK(contains(
@@ -177,7 +177,7 @@ TEST_SUITE("InteractionGenerator")
         auto code = generate_interactions(desc);
 
         // Should have concept version only
-        CHECK(contains(code, "template<std::integral T>"));
+        CHECK(contains(code, "template <std::integral T>"));
 
         // Should not have feature detection
         CHECK_FALSE(contains(code, "#if __cpp_concepts"));
@@ -254,8 +254,8 @@ TEST_SUITE("InteractionGenerator")
         auto code = generate_interactions(desc);
 
         // Should have two template parameters TL and TR
-        CHECK(contains(code, "template<std::integral TL>"));
-        CHECK(contains(code, "template<std::floating_point TR>"));
+        CHECK(contains(code, "template <std::integral TL>"));
+        CHECK(contains(code, "template <std::floating_point TR>"));
         CHECK(contains(code, "operator*(TL lhs, TR rhs)"));
     }
 
@@ -794,12 +794,12 @@ TEST_SUITE("InteractionGenerator")
             // Should have non-constexpr atlas_value
             CHECK(contains(
                 code,
-                "inline auto atlas_value(::external::OtherType const& v, "
+                "inline auto\natlas_value(::external::OtherType const& v, "
                 "value_tag)"));
             // Should NOT have constexpr
             CHECK_FALSE(contains(
                 code,
-                "inline constexpr auto atlas_value(::external::OtherType "
+                "inline constexpr auto\natlas_value(::external::OtherType "
                 "const& v, value_tag)"));
         }
 
@@ -828,7 +828,7 @@ TEST_SUITE("InteractionGenerator")
             // Should have constexpr atlas_value
             CHECK(contains(
                 code,
-                "inline constexpr auto atlas_value(::external::OtherType "
+                "inline constexpr auto\natlas_value(::external::OtherType "
                 "const& v, value_tag)"));
         }
 
@@ -872,11 +872,11 @@ TEST_SUITE("InteractionGenerator")
             // non-constexpr
             CHECK(contains(
                 code,
-                "inline auto atlas_value(::external::Shared const& v, "
+                "inline auto\natlas_value(::external::Shared const& v, "
                 "value_tag)"));
             CHECK_FALSE(contains(
                 code,
-                "inline constexpr auto atlas_value(::external::Shared const& "
+                "inline constexpr auto\natlas_value(::external::Shared const& "
                 "v, value_tag)"));
         }
 
@@ -906,11 +906,11 @@ TEST_SUITE("InteractionGenerator")
             // fallback
             CHECK(contains(
                 code,
-                "inline auto atlas_value(::external::OtherType const& v, "
+                "inline auto\natlas_value(::external::OtherType const& v, "
                 "value_tag)"));
             CHECK_FALSE(contains(
                 code,
-                "inline constexpr auto atlas_value(::external::OtherType "
+                "inline constexpr auto\natlas_value(::external::OtherType "
                 "const& v, value_tag)"));
         }
     }


### PR DESCRIPTION
## Summary
- Added CMake custom commands to auto-generate showcase examples during build
- `showcase_examples` target automatically rebuilds when atlas tool or input files change
- Ensures showcase files stay up-to-date with implementation changes
- Improved template formatting for better code readability (compound operator templates)

## Changes
- Added `add_custom_command` for `strong_types_showcase.hpp` and `interactions_showcase.hpp`
- Added `showcase_examples` target to the default ALL target
- Regenerated showcase files with improved formatting

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)