### PR TITLE
Fix formatting: add spaces around operators

### DIFF
--- a/examples/generated/interactions_showcase.hpp
+++ b/examples/generated/interactions_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780
-#define EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780
+#ifndef EXAMPLE_INTERACTIONS_8CAF909640A5375E7AF68E95192B125DAE92EE7E
+#define EXAMPLE_INTERACTIONS_8CAF909640A5375E7AF68E95192B125DAE92EE7E
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -34,7 +34,7 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto operator<=>(
+    friend auto operator <=> (
         strong_type_tag const &,
         strong_type_tag const &) = default;
 #endif
@@ -140,7 +140,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto operator ()(T && t) const
+    constexpr auto operator () (T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));
@@ -1179,4 +1179,4 @@ operator+(EncryptedData lhs, EncryptedData rhs)
 
 } // namespace security
 
-#endif // EXAMPLE_INTERACTIONS_7E8A8E301643676EDDA5E809ED56ECDCCD56F780
+#endif // EXAMPLE_INTERACTIONS_8CAF909640A5375E7AF68E95192B125DAE92EE7E

--- a/examples/generated/strong_types_showcase.hpp
+++ b/examples/generated/strong_types_showcase.hpp
@@ -41,7 +41,7 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto operator<=>(
+    friend auto operator <=> (
         strong_type_tag const &,
         strong_type_tag const &) = default;
 #endif
@@ -147,7 +147,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto operator ()(T && t) const
+    constexpr auto operator () (T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));

--- a/src/lib/AtlasUtilities.cpp
+++ b/src/lib/AtlasUtilities.cpp
@@ -85,7 +85,7 @@ struct strong_type_tag
 {
 #if defined(__cpp_impl_three_way_comparison) && \
     __cpp_impl_three_way_comparison >= 201907L
-    friend auto operator<=>(
+    friend auto operator <=> (
         strong_type_tag const &,
         strong_type_tag const &) = default;
 #endif
@@ -191,7 +191,7 @@ class Value
 
 public:
     template <typename T>
-    constexpr auto operator ()(T && t) const
+    constexpr auto operator () (T && t) const
     -> decltype(rval<T>(atlas_detail::value(t, atlas_detail::value_tag{})))
     {
         return rval<T>(atlas_detail::value(t, atlas_detail::value_tag{}));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -203,6 +203,6 @@ doctest_discover_tests(generated_code_ut TEST_PREFIX "Generated Code : ")
 doctest_discover_tests(atlas_tool_ut TEST_PREFIX "Atlas Tool : "
     PROPERTIES ENVIRONMENT "BUILD_DIR=${CMAKE_BINARY_DIR}"
 )
-doctest_discover_tests(interaction_generator_ut TEST_PREFIX "Interaction Generator : ")
-doctest_discover_tests(interaction_compilation_ut TEST_PREFIX "Interaction Compilation : ")
-doctest_discover_tests(structural_validation_demo_ut TEST_PREFIX "Structural Demo : ")
+doctest_discover_tests(interaction_generator_ut TEST_PREFIX "Interaction Generator : ")
+doctest_discover_tests(interaction_compilation_ut TEST_PREFIX "Interaction Compilation : ")
+doctest_discover_tests(structural_validation_demo_ut TEST_PREFIX "Structural Demo : ")


### PR DESCRIPTION
## Summary
- Add spaces around `<=>` and `()` operators for improved readability
- Remove trailing whitespace in CMakeLists.txt
- Apply formatting consistently across generated files and utilities

## Changes
- `operator<=>` → `operator <=> `
- `operator()` → `operator () `
- Clean up trailing whitespace in test configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)