### PR TITLE
Fix value access on primitive types in interactions

### DIFF
--- a/examples/generated/interactions_showcase.hpp
+++ b/examples/generated/interactions_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2
-#define EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2
+#ifndef EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29
+#define EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -952,19 +952,26 @@ operator^(RedChannel lhs, RedChannel rhs)
 
 namespace math {
 
-inline constexpr T
+template <std::integral T>
+constexpr T
 operator+(T lhs, T rhs)
 {
     return T{lhs.value + atlas::value(rhs)};
 }
 
-inline constexpr U
+template <typename U, typename std::enable_if<std::is_floating_point<U>::value, bool>::type = true>
+constexpr U
 operator*(U lhs, U rhs)
 {
     return U{lhs.value * atlas::value(rhs)};
 }
 
-inline constexpr V
+#if __cpp_concepts >= 201907L
+template <std::integral V>
+#else
+template <typename V, typename std::enable_if<sizeof(V) <= 8, bool>::type = true>
+#endif
+constexpr V
 operator-(V lhs, V rhs)
 {
     return V{lhs.value - atlas::value(rhs)};
@@ -1144,4 +1151,4 @@ operator+(EncryptedData lhs, EncryptedData rhs)
 
 } // namespace security
 
-#endif // EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2
+#endif // EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29

--- a/examples/generated/interactions_showcase.hpp
+++ b/examples/generated/interactions_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_INTERACTIONS_55468202C265B8705E260179EAF8490B47EA8217
-#define EXAMPLE_INTERACTIONS_55468202C265B8705E260179EAF8490B47EA8217
+#ifndef EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2
+#define EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -263,27 +263,6 @@ atlas_value(::physics::units::Seconds const& v, value_tag)
 
 inline constexpr auto
 atlas_value(::security::EncryptedData const& v, value_tag)
--> decltype(v.value)
-{
-    return v.value;
-}
-
-inline constexpr auto
-atlas_value(double const& v, value_tag)
--> decltype(v.value)
-{
-    return v.value;
-}
-
-inline constexpr auto
-atlas_value(int const& v, value_tag)
--> decltype(v.value)
-{
-    return v.value;
-}
-
-inline constexpr auto
-atlas_value(size_t const& v, value_tag)
 -> decltype(v.value)
 {
     return v.value;
@@ -826,13 +805,13 @@ namespace app::config {
 inline constexpr ConfigKey
 operator+(ConfigKey lhs, std::string rhs)
 {
-    return ConfigKey{lhs.value + atlas::value(rhs)};
+    return ConfigKey{lhs.value + rhs};
 }
 
 inline constexpr ConfigKey
 operator+(std::string lhs, ConfigKey rhs)
 {
-    return ConfigKey{lhs.value + atlas::value(rhs)};
+    return ConfigKey{lhs + atlas::value(rhs)};
 }
 
 } // namespace app::config
@@ -864,13 +843,13 @@ operator-(ByteCount lhs, ByteCount rhs)
 inline constexpr ByteCount
 operator*(ByteCount lhs, size_t rhs)
 {
-    return ByteCount{lhs.value * rhs.value};
+    return ByteCount{lhs.value * rhs};
 }
 
 inline constexpr ByteCount
 operator/(ByteCount lhs, size_t rhs)
 {
-    return ByteCount{lhs.value / rhs.value};
+    return ByteCount{lhs.value / rhs};
 }
 
 inline constexpr ByteCount
@@ -898,13 +877,13 @@ operator-(Money lhs, Money rhs)
 inline constexpr Money
 operator*(Money lhs, double rhs)
 {
-    return Money{lhs.value * rhs.value};
+    return Money{lhs.value * rhs};
 }
 
 inline constexpr Money
 operator/(Money lhs, double rhs)
 {
-    return Money{lhs.value / rhs.value};
+    return Money{lhs.value / rhs};
 }
 
 inline constexpr double
@@ -920,13 +899,13 @@ namespace geo {
 inline constexpr Latitude
 operator+(Latitude lhs, double rhs)
 {
-    return Latitude{lhs.value + rhs.value};
+    return Latitude{lhs.value + rhs};
 }
 
 inline constexpr Longitude
 operator+(Longitude lhs, double rhs)
 {
-    return Longitude{lhs.value + rhs.value};
+    return Longitude{lhs.value + rhs};
 }
 
 inline constexpr double
@@ -973,26 +952,19 @@ operator^(RedChannel lhs, RedChannel rhs)
 
 namespace math {
 
-template <std::integral T>
-constexpr T
+inline constexpr T
 operator+(T lhs, T rhs)
 {
     return T{lhs.value + atlas::value(rhs)};
 }
 
-template <typename U, typename std::enable_if<std::is_floating_point<U>::value, bool>::type = true>
-constexpr U
+inline constexpr U
 operator*(U lhs, U rhs)
 {
     return U{lhs.value * atlas::value(rhs)};
 }
 
-#if __cpp_concepts >= 201907L
-template <std::integral V>
-#else
-template <typename V, typename std::enable_if<sizeof(V) <= 8, bool>::type = true>
-#endif
-constexpr V
+inline constexpr V
 operator-(V lhs, V rhs)
 {
     return V{lhs.value - atlas::value(rhs)};
@@ -1057,13 +1029,13 @@ operator^(Octet lhs, Octet rhs)
 inline constexpr Octet
 operator<<(Octet lhs, int rhs)
 {
-    return Octet{lhs.value << rhs.value};
+    return Octet{lhs.value << rhs};
 }
 
 inline constexpr Octet
 operator>>(Octet lhs, int rhs)
 {
-    return Octet{lhs.value >> rhs.value};
+    return Octet{lhs.value >> rhs};
 }
 
 } // namespace net::ipv4
@@ -1085,19 +1057,19 @@ operator-(Meters lhs, Meters rhs)
 inline constexpr Meters
 operator*(Meters lhs, double rhs)
 {
-    return Meters{lhs.value * rhs.value};
+    return Meters{lhs.value * rhs};
 }
 
 inline constexpr Meters
 operator*(double lhs, Meters rhs)
 {
-    return Meters{lhs.value * rhs.value};
+    return Meters{lhs * rhs.value};
 }
 
 inline constexpr Meters
 operator/(Meters lhs, double rhs)
 {
-    return Meters{lhs.value / rhs.value};
+    return Meters{lhs.value / rhs};
 }
 
 inline constexpr double
@@ -1121,19 +1093,19 @@ operator-(Seconds lhs, Seconds rhs)
 inline constexpr Seconds
 operator*(Seconds lhs, double rhs)
 {
-    return Seconds{lhs.value * rhs.value};
+    return Seconds{lhs.value * rhs};
 }
 
 inline constexpr Seconds
 operator*(double lhs, Seconds rhs)
 {
-    return Seconds{lhs.value * rhs.value};
+    return Seconds{lhs * rhs.value};
 }
 
 inline constexpr Seconds
 operator/(Seconds lhs, double rhs)
 {
-    return Seconds{lhs.value / rhs.value};
+    return Seconds{lhs.value / rhs};
 }
 
 inline constexpr double
@@ -1172,4 +1144,4 @@ operator+(EncryptedData lhs, EncryptedData rhs)
 
 } // namespace security
 
-#endif // EXAMPLE_INTERACTIONS_55468202C265B8705E260179EAF8490B47EA8217
+#endif // EXAMPLE_INTERACTIONS_0E9402ACBA979915E8C8E1355A27B8C6F8D6B2F2


### PR DESCRIPTION
## Summary
- Fixed generator incorrectly applying `.value` to primitive types (`double`, `int`, `size_t`) and std library types (`std::string`)
- Primitives and std types are now used directly without value access
- Eliminated generation of invalid `atlas_value` overloads for primitives

## Changes
- Modified `generate_value_access()` to be type-aware via `classify_type()`
- Primitives and std library types bypass custom value access logic
- Updated atlas_value generation to skip primitives and std types
- Added comprehensive test coverage for all scenarios

## Test Coverage
- Primitive RHS types (size_t, double, int) used directly
- Primitive LHS types used directly  
- std::string and std library types used directly
- Atlas types still correctly use `.value` access
- No atlas_value overloads generated for primitives

## Before
```cpp
Money{lhs.value * rhs.value}  // ❌ rhs is double
atlas_value(double const& v, value_tag)  // ❌ Invalid for primitives
```

## After
```cpp
Money{lhs.value * rhs}  // ✅ rhs used directly
// No atlas_value for primitives  // ✅ Correct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>