### PR TITLE
Add C++11 compatibility for strong type generator

### DIFF
--- a/docs/cpp-standard-compatibility.md
+++ b/docs/cpp-standard-compatibility.md
@@ -1,0 +1,238 @@
+# C++ Standard Compatibility
+
+Atlas Strong Type Generator is designed to work with C++11 and later standards, with automatic feature detection and fallbacks for maximum portability.
+
+## Minimum Requirements
+
+**C++11** is the minimum required standard for all generated code.
+
+The generator ensures that:
+- Type traits use C++11 syntax (`std::enable_if<...>::type`, `std::is_constructible<...>::value`)
+- C++17 `void_t` is manually implemented for C++11 compatibility
+- Feature test macros are used to conditionally enable modern C++ features
+
+## Core Features (C++11 Compatible)
+
+All basic strong type features work with C++11:
+
+| Feature | Description | C++11 |
+|---------|-------------|-------|
+| Basic wrapper | Strong type wrapper with value member | ✅ |
+| Copy/move semantics | Default copy/move constructors and assignment | ✅ |
+| Variadic constructor | Perfect forwarding constructor with SFINAE | ✅ |
+| Cast operators | Explicit conversion to underlying type | ✅ |
+| Arithmetic operators | `+`, `-`, `*`, `/`, `%` with compound assignments | ✅ |
+| Comparison operators | `==`, `!=`, `<`, `<=`, `>`, `>=` | ✅ |
+| Logical operators | `&&`, `||`, `not` | ✅ |
+| Bitwise operators | `&`, `|`, `^`, `~`, `<<`, `>>` | ✅ |
+| Increment/decrement | `++`, `--` (prefix and postfix) | ✅ |
+| Unary operators | `+`, `-` | ✅ |
+| Stream operators | `<<`, `>>` for iostreams | ✅ |
+| Hash support | `std::hash` specialization | ✅ |
+| Addressof operators | `operator &()`, `operator ->()` | ✅ |
+| Indirection operator | `operator *()` | ✅ |
+| Bool conversion | `explicit operator bool()` | ✅ |
+| Logical not | `operator not()` | ✅ |
+
+## Constexpr Support
+
+**User-controlled**: Whether operators are `constexpr` is determined by the user's type description, not by the C++ standard.
+
+- **C++11**: Supports `constexpr` for simple operations (single return statement)
+- **C++14+**: Supports `constexpr` for complex operations (multiple statements, assignments)
+- **C++20+**: Supports `constexpr` destructors
+
+If you specify `constexpr` in your type description and compile with C++11:
+- ✅ Simple operations (getters, const member functions) will compile
+- ❌ Complex operations (assignments, mutations) will fail to compile
+
+**Recommendation**: If targeting C++11, only use `constexpr` for types with simple operations, or compile with C++14+.
+
+## Optional Features with C++ Version Requirements
+
+Some advanced features require modern C++ standards:
+
+| Feature | C++ Version Required | Reason | Opt-in |
+|---------|---------------------|--------|--------|
+| **Subscript operator** (`[]`) | C++11 | Uses trailing return type with `decltype` | ✅ User opts-in |
+| **Callable operator** (`()`) | C++11 | Direct call; C++17 uses `std::invoke` | ✅ User opts-in |
+| **Spaceship operator** (`<=>`) | C++20 | Language feature | ✅ User opts-in |
+| **Multidimensional subscript** | C++23 | Multidimensional `operator[]` | Auto-detected |
+
+### Subscript Operator (C++11+)
+
+```cpp
+// C++11 compatible using trailing return type
+template <typename ArgT>
+constexpr auto operator [] (ArgT && arg)
+-> decltype(value[std::forward<ArgT>(arg)])
+{
+    return value[std::forward<ArgT>(arg)];
+}
+```
+
+**How to use**: Add `[]` to your type description.
+
+**C++ Version**: C++11 for single-argument subscript, C++23 for multidimensional subscript (automatically detected).
+
+### Callable Operator (C++11+)
+
+The callable operator uses feature detection to provide the best implementation for your C++ standard:
+
+**C++17+ (with `std::invoke`):**
+```cpp
+template <typename InvocableT>
+constexpr auto operator () (InvocableT && inv) const
+-> decltype(std::invoke(std::forward<InvocableT>(inv), value))
+{
+    return std::invoke(std::forward<InvocableT>(inv), value);
+}
+```
+
+**C++11/14 (direct call):**
+```cpp
+template <typename InvocableT>
+constexpr auto operator () (InvocableT && inv) const
+-> decltype(std::forward<InvocableT>(inv)(value))
+{
+    return std::forward<InvocableT>(inv)(value);
+}
+```
+
+**How to use**: Add `()` to your type description.
+
+**C++11/14 Limitations**: Direct call works with function objects, lambdas, and function pointers, but not with member function pointers or member object pointers (use C++17+ with `std::invoke` for those).
+
+### Spaceship Operator (C++20+)
+
+```cpp
+// Requires C++20 for operator <=>
+friend constexpr auto operator <=> (
+    ClassName const &,
+    ClassName const &) = default;
+```
+
+**How to use**: Add `<=>` to your type description.
+
+**Fallback**: None. Compile with `-std=c++20` or later.
+
+**Note**: When using `<=>`, you typically don't need to specify individual comparison operators (`<`, `<=`, `>`, `>=`) as they are synthesized automatically.
+
+### Multidimensional Subscript (C++23+)
+
+```cpp
+// Automatically uses C++23 feature when available
+#if __cpp_multidimensional_subscript >= 202110L
+    template <typename ArgT, typename... ArgTs>
+    constexpr decltype(auto) operator [] (ArgT && arg, ArgTs && ... args)
+    {
+        return value[std::forward<ArgT>(arg), std::forward<ArgTs>(args)...];
+    }
+#else
+    // Fallback to single-argument version
+    template <typename ArgT>
+    constexpr decltype(auto) operator [] (ArgT && arg)
+    {
+        return value[std::forward<ArgT>(arg)];
+    }
+#endif
+```
+
+**How to use**: Add `[]` to your type description. Multidimensional support is automatically detected.
+
+**Fallback**: Single-argument subscript for C++14-C++20.
+
+## Boilerplate Code Compatibility
+
+The Atlas boilerplate (included in all generated files) uses feature detection for modern C++ features:
+
+### Three-Way Comparison Support (C++20+)
+
+```cpp
+#if defined(__cpp_impl_three_way_comparison) && \
+    __cpp_impl_three_way_comparison >= 201907L
+#include <compare>
+#endif
+
+struct strong_type_tag {
+#if defined(__cpp_impl_three_way_comparison) && \
+    __cpp_impl_three_way_comparison >= 201907L
+    friend auto operator <=> (
+        strong_type_tag const &,
+        strong_type_tag const &) = default;
+#endif
+};
+```
+
+### Inline Variables (C++17+)
+
+```cpp
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
+inline constexpr auto value = atlas_detail::Value{};
+#else
+template <typename T>
+constexpr auto
+value(T && t)
+-> decltype(atlas_detail::Value{}(std::forward<T>(t)))
+{
+    return atlas_detail::Value{}(std::forward<T>(t));
+}
+#endif
+```
+
+**Fallback**: Function template for C++11-C++14.
+
+### void_t (C++17 feature, provided for C++11)
+
+```cpp
+// Manual implementation for C++11 compatibility
+template <typename... Ts>
+struct make_void {
+    using type = void;
+};
+
+template <typename... Ts>
+using void_t = typename make_void<Ts...>::type;
+```
+
+## Testing Your Generated Code
+
+To verify compatibility with different C++ standards:
+
+```bash
+# Test with C++11
+g++ -std=c++11 -fsyntax-only -Isrc/lib your_generated_file.hpp
+
+# Test with C++14
+g++ -std=c++14 -fsyntax-only -Isrc/lib your_generated_file.hpp
+
+# Test with C++17
+g++ -std=c++17 -fsyntax-only -Isrc/lib your_generated_file.hpp
+
+# Test with C++20
+g++ -std=c++20 -fsyntax-only -Isrc/lib your_generated_file.hpp
+```
+
+## CMake Integration
+
+When using Atlas with CMake, set your minimum C++ standard:
+
+```cmake
+# For maximum compatibility
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Or for modern features
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+```
+
+## Summary
+
+- ✅ **C++11**: All core features work, including subscript and callable operators
+- ✅ **C++14**: Enables constexpr for more complex operations
+- ✅ **C++17**: Adds `std::invoke` support for callable operator (member pointers), inline variables
+- ✅ **C++20**: Adds spaceship operator, constexpr destructors
+- ✅ **C++23**: Adds multidimensional subscript support
+
+**Recommendation**: C++11 provides full functionality for nearly all use cases. Use C++17 or later for member pointer invocation and additional optimizations.

--- a/examples/generated/interactions_showcase.hpp
+++ b/examples/generated/interactions_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29
-#define EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29
+#ifndef EXAMPLE_INTERACTIONS_0416387924EC60DC869827A561CD6788523D3E09
+#define EXAMPLE_INTERACTIONS_0416387924EC60DC869827A561CD6788523D3E09
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -149,7 +149,7 @@ public:
 
 } // namespace atlas_detail
 
-#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 9201606L
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 inline constexpr auto value = atlas_detail::Value{};
 #else
 template <typename T>
@@ -1151,4 +1151,4 @@ operator+(EncryptedData lhs, EncryptedData rhs)
 
 } // namespace security
 
-#endif // EXAMPLE_INTERACTIONS_08408F508DFF3C80E32683163FD44BEB26B4AF29
+#endif // EXAMPLE_INTERACTIONS_0416387924EC60DC869827A561CD6788523D3E09

--- a/examples/generated/strong_types_showcase.hpp
+++ b/examples/generated/strong_types_showcase.hpp
@@ -1,5 +1,5 @@
-#ifndef EXAMPLE_3DE9EBA0EB3063A3083FBD1081D4E1708DE7F549
-#define EXAMPLE_3DE9EBA0EB3063A3083FBD1081D4E1708DE7F549
+#ifndef EXAMPLE_E1FDB3E2656702E949EB29E24DF2AC7BB25F1DF0
+#define EXAMPLE_E1FDB3E2656702E949EB29E24DF2AC7BB25F1DF0
 
 // ======================================================================
 // NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE  NOTICE
@@ -155,7 +155,7 @@ public:
 
 } // namespace atlas_detail
 
-#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 9201606L
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 inline constexpr auto value = atlas_detail::Value{};
 #else
 template <typename T>
@@ -178,8 +178,8 @@ value(T && t)
 ///
 //////////////////////////////////////////////////////////////////////
 
-
-namespace finance::core {
+namespace finance {
+namespace core {
 
 /**
  * @brief Strong type wrapper for double
@@ -208,9 +208,9 @@ struct Money
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Money(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -386,8 +386,9 @@ struct Money
         return lhs.value >= rhs.value;
     }
 };
+} // namespace core
+} // namespace finance
 
-} // namespace finance::core
 
 /**
  * @brief std::hash specialization for finance::core::Money
@@ -406,8 +407,8 @@ struct std::hash<finance::core::Money>
             static_cast<double const &>(t));
     }
 };
-
-namespace ids::v1 {
+namespace ids {
+namespace v1 {
 
 /**
  * @brief Strong type wrapper for unsigned long
@@ -437,9 +438,9 @@ public:
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<unsigned long, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<unsigned long, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit UserId(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -477,8 +478,9 @@ public:
         return lhs.value == rhs.value;
     }
 };
+} // namespace v1
+} // namespace ids
 
-} // namespace ids::v1
 
 /**
  * @brief std::hash specialization for ids::v1::UserId
@@ -497,8 +499,8 @@ struct std::hash<ids::v1::UserId>
             static_cast<unsigned long const &>(t));
     }
 };
-
-namespace physics::units {
+namespace physics {
+namespace units {
 
 /**
  * @brief Strong type wrapper for double
@@ -527,9 +529,9 @@ struct Meters
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Meters(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -661,10 +663,11 @@ struct Meters
         return lhs.value == rhs.value;
     }
 };
+} // namespace units
+} // namespace physics
 
-} // namespace physics::units
-
-namespace physics::units {
+namespace physics {
+namespace units {
 
 /**
  * @brief Strong type wrapper for double
@@ -693,9 +696,9 @@ struct Seconds
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Seconds(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -827,10 +830,11 @@ struct Seconds
         return lhs.value == rhs.value;
     }
 };
+} // namespace units
+} // namespace physics
 
-} // namespace physics::units
-
-namespace physics::units {
+namespace physics {
+namespace units {
 
 /**
  * @brief Strong type wrapper for double
@@ -859,9 +863,9 @@ struct MetersPerSecond
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit MetersPerSecond(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -993,8 +997,8 @@ struct MetersPerSecond
         return lhs.value == rhs.value;
     }
 };
-
-} // namespace physics::units
+} // namespace units
+} // namespace physics
 
 namespace data {
 
@@ -1025,9 +1029,9 @@ struct ByteCount
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<size_t, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<size_t, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit ByteCount(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1260,10 +1264,10 @@ struct ByteCount
         return lhs.value >= rhs.value;
     }
 };
-
 } // namespace data
 
-namespace graphics::color {
+namespace graphics {
+namespace color {
 
 /**
  * @brief Strong type wrapper for uint8_t
@@ -1292,9 +1296,9 @@ struct RedChannel
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<uint8_t, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<uint8_t, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit RedChannel(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1489,8 +1493,8 @@ struct RedChannel
         return lhs.value == rhs.value;
     }
 };
-
-} // namespace graphics::color
+} // namespace color
+} // namespace graphics
 
 namespace security {
 
@@ -1522,9 +1526,9 @@ public:
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<std::string, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<std::string, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit EncryptedData(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1576,8 +1580,8 @@ public:
         return lhs.value == rhs.value;
     }
 };
-
 } // namespace security
+
 
 /**
  * @brief std::hash specialization for security::EncryptedData
@@ -1596,7 +1600,6 @@ struct std::hash<security::EncryptedData>
             static_cast<std::string const &>(t));
     }
 };
-
 namespace geo {
 
 /**
@@ -1626,9 +1629,9 @@ struct Latitude
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Latitude(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1730,7 +1733,6 @@ struct Latitude
         return lhs.value >= rhs.value;
     }
 };
-
 } // namespace geo
 
 namespace geo {
@@ -1762,9 +1764,9 @@ struct Longitude
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<double, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<double, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Longitude(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1866,7 +1868,6 @@ struct Longitude
         return lhs.value >= rhs.value;
     }
 };
-
 } // namespace geo
 
 namespace concurrency {
@@ -1898,9 +1899,9 @@ struct ThreadId
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<int, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<int, ArgTs...>::value,
+            bool>::type = true>
     explicit ThreadId(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -1952,8 +1953,8 @@ struct ThreadId
         return lhs.value == rhs.value;
     }
 };
-
 } // namespace concurrency
+
 
 /**
  * @brief std::hash specialization for concurrency::ThreadId
@@ -1972,8 +1973,8 @@ struct std::hash<concurrency::ThreadId>
             static_cast<int const &>(t));
     }
 };
-
-namespace math::rational {
+namespace math {
+namespace rational {
 
 /**
  * @brief Strong type wrapper for long
@@ -2002,9 +2003,9 @@ struct Numerator
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<long, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<long, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Numerator(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -2105,10 +2106,11 @@ struct Numerator
         return lhs.value == rhs.value;
     }
 };
+} // namespace rational
+} // namespace math
 
-} // namespace math::rational
-
-namespace math::rational {
+namespace math {
+namespace rational {
 
 /**
  * @brief Strong type wrapper for long
@@ -2137,9 +2139,9 @@ struct Denominator
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<long, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<long, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Denominator(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -2219,10 +2221,11 @@ struct Denominator
         return lhs.value == rhs.value;
     }
 };
+} // namespace rational
+} // namespace math
 
-} // namespace math::rational
-
-namespace net::ipv4 {
+namespace net {
+namespace ipv4 {
 
 /**
  * @brief Strong type wrapper for uint8_t
@@ -2251,9 +2254,9 @@ struct Octet
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<uint8_t, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<uint8_t, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit Octet(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -2399,10 +2402,11 @@ struct Octet
         return lhs.value == rhs.value;
     }
 };
+} // namespace ipv4
+} // namespace net
 
-} // namespace net::ipv4
-
-namespace app::config {
+namespace app {
+namespace config {
 
 /**
  * @brief Strong type wrapper for std::string
@@ -2432,9 +2436,9 @@ public:
 
     template <
         typename... ArgTs,
-        std::enable_if_t<
-            std::is_constructible_v<std::string, ArgTs...>,
-            bool> = true>
+        typename std::enable_if<
+            std::is_constructible<std::string, ArgTs...>::value,
+            bool>::type = true>
     constexpr explicit ConfigKey(ArgTs && ... args)
     : value(std::forward<ArgTs>(args)...)
     { }
@@ -2461,12 +2465,14 @@ public:
     }
 #else
     template <typename ArgT>
-    constexpr decltype(auto) operator [] (ArgT && arg)
+    constexpr auto operator [] (ArgT && arg)
+    -> decltype(value[std::forward<ArgT>(arg)])
     {
         return value[std::forward<ArgT>(arg)];
     }
     template <typename ArgT>
-    constexpr decltype(auto) operator [] (ArgT && arg) const
+    constexpr auto operator [] (ArgT && arg) const
+    -> decltype(value[std::forward<ArgT>(arg)])
     {
         return value[std::forward<ArgT>(arg)];
     }
@@ -2544,8 +2550,9 @@ public:
         return lhs.value == rhs.value;
     }
 };
+} // namespace config
+} // namespace app
 
-} // namespace app::config
 
 /**
  * @brief std::hash specialization for app::config::ConfigKey
@@ -2564,4 +2571,4 @@ struct std::hash<app::config::ConfigKey>
             static_cast<std::string const &>(t));
     }
 };
-#endif // EXAMPLE_3DE9EBA0EB3063A3083FBD1081D4E1708DE7F549
+#endif // EXAMPLE_E1FDB3E2656702E949EB29E24DF2AC7BB25F1DF0

--- a/src/lib/AtlasUtilities.cpp
+++ b/src/lib/AtlasUtilities.cpp
@@ -200,7 +200,7 @@ public:
 
 } // namespace atlas_detail
 
-#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 9201606L
+#if defined(__cpp_inline_variables) && __cpp_inline_variables >= 201606L
 inline constexpr auto value = atlas_detail::Value{};
 #else
 template <typename T>

--- a/tests/CodeStructureParser.hpp
+++ b/tests/CodeStructureParser.hpp
@@ -143,6 +143,7 @@ private:
     void extract_type_info(std::string const & code, CodeStructure & result);
     void extract_operators(std::string const & code, CodeStructure & result);
     void extract_hash_info(std::string const & code, CodeStructure & result);
+    std::string extract_namespace_name(std::string const & search_area);
 };
 
 } // namespace wjh::atlas::testing


### PR DESCRIPTION
## Summary

Comprehensive audit and enhancement to ensure all generated code is fully C++11 compatible, with feature detection and appropriate fallbacks for modern C++ features.

### Core Changes

- **Type traits**: Migrated to C++11 syntax (`std::is_constructible<T>::value` instead of `std::is_constructible_v<T>`)
- **SFINAE**: Updated to use `typename std::enable_if<...>::type` instead of `std::enable_if_t<...>`
- **Namespace declarations**: Expanded nested namespaces for C++11 compatibility (`namespace foo {\nnamespace bar {` instead of `namespace foo::bar {`)
- **Feature detection**: Added proper feature test macros for optional modern C++ features

### Feature-Specific Improvements

**Subscript Operator (`[]`)**
- Now uses trailing return type syntax for C++11 compatibility
- Maintains support for C++23 multidimensional subscript when available

**Callable Operator (`()`)**
- Added C++11 fallback using direct invocation
- C++17+ uses `std::invoke` for full member pointer support
- Automatically selects best implementation based on feature detection

**Boilerplate Code**
- Fixed typo in inline variables feature test macro (9201606L → 201606L)
- Proper C++11 fallback for inline variables (function template)
- Three-way comparison support properly feature-detected

### Documentation

Added comprehensive `docs/cpp-standard-compatibility.md` documenting:
- Minimum C++11 requirements
- Feature availability across C++ standards
- Constexpr limitations and recommendations
- Testing procedures for different standards
- CMake integration examples

### Testing

All generated code verified to compile with:
- C++11 (all core features)
- C++14 (enhanced constexpr)
- C++17 (std::invoke, inline variables)
- C++20 (spaceship operator, constexpr destructors)
- C++23 (multidimensional subscript)

### Breaking Changes

None - all changes are backward compatible and improve portability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)