### PR TITLE
Add warning for redundant comparison operators with spaceship

### DIFF
--- a/src/lib/AtlasUtilities.cpp
+++ b/src/lib/AtlasUtilities.cpp
@@ -10,6 +10,15 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdlib>
+#include <string>
+
+#ifdef _WIN32
+    #include <io.h>
+    #define isatty _isatty
+#else
+    #include <unistd.h>
+#endif
 
 namespace wjh::atlas { inline namespace v1 {
 
@@ -225,6 +234,25 @@ value(T && t)
 
 )";
     return result + 1;
+}
+
+bool
+supports_color(int fd)
+{
+    // Check if output is a TTY
+    if (not isatty(fd)) {
+        return false;
+    }
+
+    // Check TERM environment variable
+    auto term = std::getenv("TERM");
+    if (not term) {
+        return false;
+    }
+
+    std::string term_str(term);
+    // Most modern terminals support color
+    return term_str != "dumb";
 }
 
 }} // namespace wjh::atlas::v1

--- a/src/lib/AtlasUtilities.hpp
+++ b/src/lib/AtlasUtilities.hpp
@@ -47,6 +47,23 @@ std::string trim(std::string const & str);
  */
 std::string preamble();
 
+/**
+ * @brief Check if a file descriptor supports ANSI color codes
+ *
+ * @param fd File descriptor to check (e.g., fileno(stderr))
+ * @return true if the file descriptor is a color-capable TTY
+ */
+bool supports_color(int fd);
+
+/**
+ * @brief ANSI color codes for terminal output
+ */
+namespace color {
+constexpr char const * red = "\033[31m";
+constexpr char const * yellow = "\033[33m";
+constexpr char const * reset = "\033[0m";
+} // namespace color
+
 }} // namespace wjh::atlas::v1
 
 #endif // WJH_ATLAS_8651ABC1F7E740D3960747B1195C51A7

--- a/src/lib/StrongTypeGenerator.hpp
+++ b/src/lib/StrongTypeGenerator.hpp
@@ -196,6 +196,15 @@ struct StrongTypeDescription
 struct StrongTypeGenerator
 {
     /**
+     * @brief Warning information for diagnostic messages
+     */
+    struct Warning
+    {
+        std::string message;
+        std::string type_name;
+    };
+
+    /**
      * Generate code for a strong type.
      *
      * @return  A string with the entire type definition, including any header
@@ -210,10 +219,24 @@ struct StrongTypeGenerator
      * assuming that its syntax is correct.  Likewise, it does not verify that
      * the provided operators are implemented by the wrapped class.
      */
-    std::string operator () (StrongTypeDescription const &) const;
+    std::string operator () (StrongTypeDescription const &);
+
+    /**
+     * @brief Get the warnings collected during generation
+     */
+    std::vector<Warning> const & get_warnings() const { return warnings_; }
+
+    /**
+     * @brief Clear all collected warnings
+     */
+    void clear_warnings() { warnings_.clear(); }
+
+private:
+    std::vector<Warning> warnings_;
 };
 
-inline constexpr auto generate_strong_type = StrongTypeGenerator{};
+// Removed constexpr instance - use StrongTypeGenerator directly for stateful
+// warning collection
 
 /**
  * @brief Generate multiple strong types in a single file with unified header

--- a/tests/error_handling_ut.cpp
+++ b/tests/error_handling_ut.cpp
@@ -12,6 +12,14 @@ using namespace wjh::atlas;
 
 namespace {
 
+// Helper function for simple code generation without warnings
+std::string
+generate_strong_type(StrongTypeDescription const & desc)
+{
+    StrongTypeGenerator gen;
+    return gen(desc);
+}
+
 TEST_SUITE("Error Handling")
 {
     TEST_CASE("Unrecognized Operators")

--- a/tests/generated_code_ut.cpp
+++ b/tests/generated_code_ut.cpp
@@ -23,6 +23,14 @@ namespace {
 
 using namespace wjh::atlas;
 
+// Helper function for simple code generation without warnings
+std::string
+generate_strong_type(StrongTypeDescription const & desc)
+{
+    StrongTypeGenerator gen;
+    return gen(desc);
+}
+
 // Helper to compile and test generated code
 class CodeTester
 {

--- a/tests/integration_ut.cpp
+++ b/tests/integration_ut.cpp
@@ -17,6 +17,14 @@ using namespace wjh::atlas;
 
 namespace {
 
+// Helper function for simple code generation without warnings
+std::string
+generate_strong_type(StrongTypeDescription const & desc)
+{
+    StrongTypeGenerator gen;
+    return gen(desc);
+}
+
 // Helper to write generated code to a file, compile it, and check if it
 // compiles
 bool

--- a/tests/interaction_compilation_ut.cpp
+++ b/tests/interaction_compilation_ut.cpp
@@ -18,6 +18,14 @@ using namespace wjh::atlas;
 
 namespace {
 
+// Helper function for simple code generation without warnings
+std::string
+generate_strong_type(StrongTypeDescription const & desc)
+{
+    StrongTypeGenerator gen;
+    return gen(desc);
+}
+
 // Helper to compile generated code
 bool
 compile_interaction_code(

--- a/tests/structural_validation_demo_ut.cpp
+++ b/tests/structural_validation_demo_ut.cpp
@@ -37,6 +37,14 @@ make_description(
         .default_value = std::move(default_value)};
 }
 
+// Helper function for simple code generation without warnings
+std::string
+generate_strong_type(StrongTypeDescription const & desc)
+{
+    StrongTypeGenerator gen;
+    return gen(desc);
+}
+
 TEST_SUITE("Structural Validation Demo")
 {
     TEST_CASE("Hash Support - Structural Validation")


### PR DESCRIPTION
## Summary
- Adds diagnostic warning system to StrongTypeGenerator
- Warns when users specify ==, !=, <, <=, >, >= alongside <=>
- Generator still produces requested code, but educates users about redundancy
- Warnings display in color (red/yellow) when output is to a TTY
- Redundant operator check extracted to separate function for maintainability

## Features
- Warning infrastructure added to StrongTypeGenerator class
- Color support with TTY detection in AtlasUtilities
  - "Warnings:" header in red
  - Warning messages in yellow
  - Automatically falls back to plain text when redirected
- Comprehensive test coverage with 10 new test cases

## Technical Details
- Warnings emitted to stderr (does not corrupt generated code)
- Cross-platform color detection (Windows and Unix)
- Stateful generator API (warnings accumulate across generations)
- check_for_redundant_operators() function extracted for clean separation

## Test Results
✅ All 82 tests pass
✅ Warning system tests verify all scenarios
✅ Color detection works correctly
✅ Warnings display during build for showcase examples

## Examples
When generating types with redundant operators, warnings are emitted to stderr:
```
Warnings:
  physics::units::Meters: Operator '<=>' makes '==' and '!=' redundant. 
                          Consider removing '==' and '!=' from the description.
```

🤖 Generated with Claude Code