### PR TITLE
Add interaction helper functions and reorganize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ buys you just enough time to have a production issue in time to tank next quarte
 
 ## Quick Start
 
+The easiest way to use Atlas in your CMake project:
+
 ```cmake
 include(FetchContent)
 FetchContent_Declare(Atlas
@@ -22,16 +24,41 @@ FetchContent_Declare(Atlas
     GIT_TAG main)
 FetchContent_MakeAvailable(Atlas)
 
-add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/UserId.hpp
-    COMMAND ${Atlas_EXECUTABLE}
-        --kind=struct --namespace=myapp --name=UserId
-        --description="strong int; ==, !=, <=>"
-        --output=${CMAKE_CURRENT_BINARY_DIR}/UserId.hpp
-    DEPENDS Atlas::atlas)
+# Generate a strong type with minimal syntax
+atlas_add_type(UserId int "==, !=, <=>" TARGET my_library)
 ```
 
-See [`docs/cmake-integration.md`](docs/cmake-integration.md) for complete examples.
+That's it! The helper function automatically:
+- Generates the header file in your source directory
+- Adds it to your target's sources
+- Sets up proper build dependencies
+
+### More Helper Functions
+
+```cmake
+# Generate multiple types from a file
+add_atlas_strong_types_from_file(
+    INPUT types.txt
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Types.hpp
+    TARGET my_library)
+
+# Generate cross-type interactions (e.g., Price * Quantity -> Total)
+add_atlas_interactions_inline(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Interactions.hpp
+    TARGET my_library
+    CONTENT "
+include \"Price.hpp\"
+include \"Quantity.hpp\"
+include \"Total.hpp\"
+
+namespace=commerce
+
+Price * Quantity -> Total
+Price * int <-> Price
+")
+```
+
+See [`docs/AtlasHelpers.md`](docs/AtlasHelpers.md) for complete reference of all helper functions, or [`docs/cmake-integration.md`](docs/cmake-integration.md) for advanced integration patterns.
 
 ## Installation
 

--- a/docs/cmake-integration.md
+++ b/docs/cmake-integration.md
@@ -1,8 +1,114 @@
 # CMake Integration
 
-## FetchContent (The Easy Way)
+## The Easy Way: Helper Functions
 
-Because who wants to manually install dependencies like it's 1999?
+Atlas provides convenient CMake helper functions that handle all the boilerplate for you. These are automatically available when you use `find_package(Atlas)` or `FetchContent`:
+
+```cmake
+include(FetchContent)
+FetchContent_Declare(Atlas
+    GIT_REPOSITORY https://github.com/jodyhagins/Atlas.git
+    GIT_TAG main)
+FetchContent_MakeAvailable(Atlas)
+
+# Generate a single type with minimal syntax
+atlas_add_type(UserId int "==, !=, <=>" TARGET my_library)
+```
+
+### Available Helper Functions
+
+#### 1. `atlas_add_type()` - Quick single-type generation
+
+```cmake
+# Simplest form - namespace auto-deduced from directory structure
+atlas_add_type(UserId int "==, !=, <=>")
+
+# With target integration
+atlas_add_type(Price double "+, -, *, /, <=>" TARGET my_lib)
+
+# With additional options
+atlas_add_type(Distance double "+, -, *, /, <=>"
+    TARGET my_lib
+    DEFAULT_VALUE 0.0
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Distance.hpp)
+```
+
+#### 2. `add_atlas_strong_type()` - Full-featured generation
+
+```cmake
+add_atlas_strong_type(
+    NAME Distance
+    TYPE double
+    DESCRIPTION "+, -, *, /, <=>"
+    NAMESPACE geometry
+    KIND struct
+    DEFAULT_VALUE 0.0
+    TARGET my_library)
+```
+
+#### 3. `add_atlas_strong_types_from_file()` - Generate from file
+
+```cmake
+add_atlas_strong_types_from_file(
+    INPUT types.txt
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Types.hpp
+    TARGET my_library)
+```
+
+#### 4. `add_atlas_strong_types_inline()` - Inline definitions
+
+```cmake
+add_atlas_strong_types_inline(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Types.hpp
+    TARGET my_library
+    CONTENT "
+[type]
+namespace=app
+name=UserId
+description=strong int; ==, !=, <=>
+
+[type]
+namespace=app
+name=SessionId
+description=strong int; ==, !=, hash
+")
+```
+
+#### 5. `add_atlas_interactions_from_file()` - Cross-type interactions from file
+
+```cmake
+add_atlas_interactions_from_file(
+    INPUT interactions.txt
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/Interactions.hpp
+    TARGET my_library)
+```
+
+#### 6. `add_atlas_interactions_inline()` - Inline interaction definitions
+
+```cmake
+add_atlas_interactions_inline(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/CommerceOps.hpp
+    TARGET my_library
+    CONTENT "
+include \"Price.hpp\"
+include \"Quantity.hpp\"
+include \"Total.hpp\"
+
+namespace=commerce
+
+Price * Quantity -> Total
+Price * int <-> Price
+Quantity * int <-> Quantity
+")
+```
+
+See [`AtlasHelpers.md`](AtlasHelpers.md) for complete documentation of all helper functions, parameters, and examples.
+
+## Advanced Integration: Manual Control
+
+For cases where you need fine-grained control over the build process, you can use Atlas directly with CMake's `add_custom_command`:
+
+### Using FetchContent with add_custom_command
 
 ```cmake
 include(FetchContent)
@@ -12,7 +118,6 @@ FetchContent_Declare(Atlas
 FetchContent_MakeAvailable(Atlas)
 
 # Escape semicolons because CMake treats them like list separators
-# (yes, this is annoying, no we can't fix it)
 set(DESC "strong int\\; ==, !=, <=>")
 
 add_custom_command(
@@ -25,9 +130,9 @@ add_custom_command(
     VERBATIM)
 ```
 
-## Reusable Function (DRY Principle Applied)
+### Creating a Reusable Function (DRY Principle)
 
-Stop copy-pasting like a caveman:
+If you need custom behavior beyond what the helper functions provide:
 
 ```cmake
 function(generate_strong_type NAMESPACE TYPE_NAME DESCRIPTION)
@@ -53,7 +158,34 @@ generate_strong_type("myapp" "UserId" "strong int; ==, !=")
 generate_strong_type("myapp" "Price" "strong double; +, -, *")
 ```
 
-## Using find_package (The Traditional Way)
+### Generating Interactions Manually
+
+For cross-type interactions without helper functions:
+
+```cmake
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/interactions.hpp
+    COMMAND ${Atlas_EXECUTABLE}
+        --input=${CMAKE_CURRENT_SOURCE_DIR}/interactions.txt
+        --interactions=true
+        --output=${CMAKE_CURRENT_BINARY_DIR}/interactions.hpp
+    DEPENDS Atlas::atlas ${CMAKE_CURRENT_SOURCE_DIR}/interactions.txt
+    VERBATIM)
+```
+
+**interactions.txt:**
+```
+include "Price.hpp"
+include "Quantity.hpp"
+include "Total.hpp"
+
+namespace=commerce
+
+Price * Quantity -> Total
+Price * int <-> Price
+```
+
+### Using find_package (Traditional Installation)
 
 For the control freaks who want to install things properly:
 


### PR DESCRIPTION
## Summary

Adds convenient CMake helper functions for cross-type interaction generation and reorganizes documentation to prioritize helper functions over verbose manual approaches.

## Changes

- **New CMake functions:** `add_atlas_interactions_from_file()` and `add_atlas_interactions_inline()`
- **README.md:** Updated Quick Start to show `atlas_add_type()` helper instead of verbose `add_custom_command`
- **docs/cmake-integration.md:** Restructured to show helper functions first, verbose approaches moved to "Advanced Integration"
- **docs/AtlasHelpers.md:** Added complete documentation for interaction helpers with examples

Verbose approaches remain fully documented as advanced options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)