### PR TITLE
Fix error with drilling support

### DIFF
--- a/src/lib/atlas/AtlasUtilities.cpp
+++ b/src/lib/atlas/AtlasUtilities.cpp
@@ -612,6 +612,10 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     // Hash drilling boilerplate - only included when hash specialization is
     // needed
     static constexpr char const hash_drill_boilerplate[] = R"(
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
 // ----------------------------------------------------------------------------
 // Hash drilling support
 // ----------------------------------------------------------------------------
@@ -658,11 +662,18 @@ auto hash_drill(T const & t, PriorityTag<0>)
 {
     return hash_drill(atlas_value_for(t), PriorityTag<2>{});
 }
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 )";
 
     // OStream drilling boilerplate - only included when ostream operator is
     // needed
     static constexpr char const ostream_drill_boilerplate[] = R"(
+#ifndef WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+#define WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+namespace atlas {
+namespace atlas_detail {
 // ----------------------------------------------------------------------------
 // OStream drilling support
 // ----------------------------------------------------------------------------
@@ -708,11 +719,18 @@ auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
 {
     return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
 }
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
 )";
 
     // IStream drilling boilerplate - only included when istream operator is
     // needed
     static constexpr char const istream_drill_boilerplate[] = R"(
+#ifndef WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+#define WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+namespace atlas {
+namespace atlas_detail {
 // ----------------------------------------------------------------------------
 // IStream drilling support
 // ----------------------------------------------------------------------------
@@ -761,11 +779,18 @@ auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
 {
     return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
 }
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
 )";
 
     // Format drilling boilerplate - only included when formatter specialization
     // is needed
     static constexpr char const format_drill_boilerplate[] = R"(
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
 // ----------------------------------------------------------------------------
 // Format drilling support (C++20+)
 // ----------------------------------------------------------------------------
@@ -807,6 +832,9 @@ using format_drilled_type_t =
     std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
 
 #endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 )";
 
     // Closing section of the basic boilerplate
@@ -2904,7 +2932,9 @@ public:
 
     std::string result = basic + 1;
 
-    // Add drilling sections before closing the basic boilerplate
+    // Close the basic boilerplate
+    result += basic_closing;
+
     if (options.include_hash_drill) {
         result += hash_drill_boilerplate;
     }
@@ -2917,11 +2947,6 @@ public:
     if (options.include_format_drill) {
         result += format_drill_boilerplate;
     }
-
-    // Close the basic boilerplate
-    result += basic_closing;
-
-    // Add other optional sections
     if (options.include_arrow_operator_traits ||
         options.include_dereference_operator_traits)
     {

--- a/tests/fixtures/golden/integration/combined-features.expected
+++ b/tests/fixtures/golden/integration/combined-features.expected
@@ -383,95 +383,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -532,6 +443,109 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/formatter-format.expected
+++ b/tests/fixtures/golden/integration/formatter-format.expected
@@ -382,48 +382,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -484,6 +442,55 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/hash-unordered-map.expected
+++ b/tests/fixtures/golden/integration/hash-unordered-map.expected
@@ -380,53 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -487,6 +440,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/odr-violation-type2.expected
+++ b/tests/fixtures/golden/integration/odr-violation-type2.expected
@@ -381,53 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -488,6 +441,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/profile-deduplication.expected
+++ b/tests/fixtures/golden/integration/profile-deduplication.expected
@@ -380,53 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -487,6 +440,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/profile-with-extras.expected
+++ b/tests/fixtures/golden/integration/profile-with-extras.expected
@@ -383,95 +383,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -532,6 +443,109 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/profile-with-forwarding.expected
+++ b/tests/fixtures/golden/integration/profile-with-forwarding.expected
@@ -382,53 +382,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -489,6 +442,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/integration/stream-stringstream.expected
+++ b/tests/fixtures/golden/integration/stream-stringstream.expected
@@ -381,101 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// OStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_ostreamable<T>: detects if T can be written to std::ostream
-template <typename T, typename = void>
-struct is_ostreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_ostreamable<
-    T,
-    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly ostreamable
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << t;
-}
-
-// Enum fallback: T is an enum without operator<<, use underlying type
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << static_cast<typename std::underlying_type<T>::type>(t);
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
--> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
-// ----------------------------------------------------------------------------
-// IStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_istreamable<T>: detects if T can be read from std::istream
-template <typename T, typename = void>
-struct is_istreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_istreamable<
-    T,
-    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly istreamable
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_istreamable<T>::value,
-    std::istream &>::type
-{
-    return strm >> t;
-}
-
-// Enum fallback: T is an enum without operator>>, read as underlying type
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_istreamable<T>::value,
-    std::istream &>::type
-{
-    typename std::underlying_type<T>::type tmp;
-    strm >> tmp;
-    t = static_cast<T>(tmp);
-    return strm;
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
--> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -536,6 +441,115 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+#define WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// OStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_ostreamable<T>: detects if T can be written to std::ostream
+template <typename T, typename = void>
+struct is_ostreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_ostreamable<
+    T,
+    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly ostreamable
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << t;
+}
+
+// Enum fallback: T is an enum without operator<<, use underlying type
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << static_cast<typename std::underlying_type<T>::type>(t);
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
+-> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+
+#ifndef WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+#define WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// IStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_istreamable<T>: detects if T can be read from std::istream
+template <typename T, typename = void>
+struct is_istreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_istreamable<
+    T,
+    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly istreamable
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_istreamable<T>::value,
+    std::istream &>::type
+{
+    return strm >> t;
+}
+
+// Enum fallback: T is an enum without operator>>, read as underlying type
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_istreamable<T>::value,
+    std::istream &>::type
+{
+    typename std::underlying_type<T>::type tmp;
+    strm >> tmp;
+    t = static_cast<T>(tmp);
+    return strm;
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
+-> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/constraints/composition-complex.expected
+++ b/tests/fixtures/golden/strong-types/constraints/composition-complex.expected
@@ -386,53 +386,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -493,6 +446,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 #ifndef WJH_ATLAS_8BF8485B2F9D45ACAD473DC5B3274DDF
 #define WJH_ATLAS_8BF8485B2F9D45ACAD473DC5B3274DDF

--- a/tests/fixtures/golden/strong-types/constraints/composition-features.expected
+++ b/tests/fixtures/golden/strong-types/constraints/composition-features.expected
@@ -383,53 +383,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -490,6 +443,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 #ifndef WJH_ATLAS_173D2C4FC9AA46929AD14C8BDF75D829
 #define WJH_ATLAS_173D2C4FC9AA46929AD14C8BDF75D829

--- a/tests/fixtures/golden/strong-types/edge-cases/no-constexpr-all.expected
+++ b/tests/fixtures/golden/strong-types/edge-cases/no-constexpr-all.expected
@@ -380,53 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -487,6 +440,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/forwarding/comprehensive.expected
+++ b/tests/fixtures/golden/strong-types/forwarding/comprehensive.expected
@@ -383,53 +383,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -490,6 +443,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 #ifndef WJH_ATLAS_46CE143CD5E7495DAA505B54DBD417A2
 #define WJH_ATLAS_46CE143CD5E7495DAA505B54DBD417A2

--- a/tests/fixtures/golden/strong-types/special-features/formatter-combined.expected
+++ b/tests/fixtures/golden/strong-types/special-features/formatter-combined.expected
@@ -382,48 +382,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -484,6 +442,55 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/formatter-int.expected
+++ b/tests/fixtures/golden/strong-types/special-features/formatter-int.expected
@@ -382,48 +382,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -484,6 +442,55 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/formatter-string.expected
+++ b/tests/fixtures/golden/strong-types/special-features/formatter-string.expected
@@ -383,48 +383,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Format drilling support (C++20+)
-// ----------------------------------------------------------------------------
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
-
-// Concept: T is formattable via std::formatter<T>
-template <typename T>
-concept formattable = requires(
-    std::formatter<T> f,
-    T const & t,
-    std::format_parse_context & parse_ctx,
-    std::format_context & fmt_ctx)
-{
-    f.parse(parse_ctx);
-    f.format(t, fmt_ctx);
-};
-
-// Drill to find a formattable type, returning a reference or converted value
-template <typename T>
-constexpr decltype(auto) format_value_drill(T const & t)
-{
-    if constexpr (formattable<T>) {
-        // Base case: T is directly formattable - return reference
-        return (t);
-    } else if constexpr (std::is_enum_v<T>) {
-        // Enum fallback: convert to underlying type
-        return static_cast<std::underlying_type_t<T>>(t);
-    } else if constexpr (has_atlas_value_type<T>::value) {
-        // Recursive case: drill through atlas type
-        return format_value_drill(atlas_value_for(t));
-    } else {
-        static_assert(formattable<T>, "Type is not formattable after drilling");
-    }
-}
-
-// Type trait for the drilled type
-template <typename T>
-using format_drilled_type_t =
-    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
-
-#endif // __cpp_lib_format
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -485,6 +443,55 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+#define WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Format drilling support (C++20+)
+// ----------------------------------------------------------------------------
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 202110L
+
+// Concept: T is formattable via std::formatter<T>
+template <typename T>
+concept formattable = requires(
+    std::formatter<T> f,
+    T const & t,
+    std::format_parse_context & parse_ctx,
+    std::format_context & fmt_ctx)
+{
+    f.parse(parse_ctx);
+    f.format(t, fmt_ctx);
+};
+
+// Drill to find a formattable type, returning a reference or converted value
+template <typename T>
+constexpr decltype(auto) format_value_drill(T const & t)
+{
+    if constexpr (formattable<T>) {
+        // Base case: T is directly formattable - return reference
+        return (t);
+    } else if constexpr (std::is_enum_v<T>) {
+        // Enum fallback: convert to underlying type
+        return static_cast<std::underlying_type_t<T>>(t);
+    } else if constexpr (has_atlas_value_type<T>::value) {
+        // Recursive case: drill through atlas type
+        return format_value_drill(atlas_value_for(t));
+    } else {
+        static_assert(formattable<T>, "Type is not formattable after drilling");
+    }
+}
+
+// Type trait for the drilled type
+template <typename T>
+using format_drilled_type_t =
+    std::remove_cvref_t<decltype(format_value_drill(std::declval<T const &>()))>;
+
+#endif // __cpp_lib_format
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_9B74AE244B4F4EB68DF9D80B67E1EB05
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/hash-int.expected
+++ b/tests/fixtures/golden/strong-types/special-features/hash-int.expected
@@ -380,53 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -487,6 +440,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/hash-no-constexpr.expected
+++ b/tests/fixtures/golden/strong-types/special-features/hash-no-constexpr.expected
@@ -381,53 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -488,6 +441,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/hash-string.expected
+++ b/tests/fixtures/golden/strong-types/special-features/hash-string.expected
@@ -381,53 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -488,6 +441,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/optional-kind.expected
+++ b/tests/fixtures/golden/strong-types/special-features/optional-kind.expected
@@ -381,53 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -488,6 +441,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/optional-strong-keyword.expected
+++ b/tests/fixtures/golden/strong-types/special-features/optional-strong-keyword.expected
@@ -381,53 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// Hash drilling support
-// ----------------------------------------------------------------------------
-
-// is_hashable<T>: detects if std::hash<T> is valid
-template <typename T, typename = void>
-struct is_hashable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_hashable<
-    T,
-    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
-: std::true_type
-{ };
-
-// Base case: T is directly hashable
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<T>{}(t);
-}
-
-// Enum fallback: T is an enum without std::hash, use underlying type
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_hashable<T>::value,
-    std::size_t>::type
-{
-    return std::hash<typename std::underlying_type<T>::type>{}(
-        static_cast<typename std::underlying_type<T>::type>(t));
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto hash_drill(T const & t, PriorityTag<0>)
--> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
-{
-    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -488,6 +441,60 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_771333B44A11491895F986933BB2FB41
+#define WJH_ATLAS_771333B44A11491895F986933BB2FB41
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// Hash drilling support
+// ----------------------------------------------------------------------------
+
+// is_hashable<T>: detects if std::hash<T> is valid
+template <typename T, typename = void>
+struct is_hashable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_hashable<
+    T,
+    void_t<decltype(std::hash<T>{}(std::declval<T const &>()))>>
+: std::true_type
+{ };
+
+// Base case: T is directly hashable
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<T>{}(t);
+}
+
+// Enum fallback: T is an enum without std::hash, use underlying type
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_hashable<T>::value,
+    std::size_t>::type
+{
+    return std::hash<typename std::underlying_type<T>::type>{}(
+        static_cast<typename std::underlying_type<T>::type>(t));
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto hash_drill(T const & t, PriorityTag<0>)
+-> decltype(hash_drill(atlas_value_for(t), PriorityTag<2>{}))
+{
+    return hash_drill(atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_771333B44A11491895F986933BB2FB41
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/stream-both.expected
+++ b/tests/fixtures/golden/strong-types/special-features/stream-both.expected
@@ -381,101 +381,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// OStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_ostreamable<T>: detects if T can be written to std::ostream
-template <typename T, typename = void>
-struct is_ostreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_ostreamable<
-    T,
-    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly ostreamable
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << t;
-}
-
-// Enum fallback: T is an enum without operator<<, use underlying type
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << static_cast<typename std::underlying_type<T>::type>(t);
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
--> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
-// ----------------------------------------------------------------------------
-// IStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_istreamable<T>: detects if T can be read from std::istream
-template <typename T, typename = void>
-struct is_istreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_istreamable<
-    T,
-    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly istreamable
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_istreamable<T>::value,
-    std::istream &>::type
-{
-    return strm >> t;
-}
-
-// Enum fallback: T is an enum without operator>>, read as underlying type
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_istreamable<T>::value,
-    std::istream &>::type
-{
-    typename std::underlying_type<T>::type tmp;
-    strm >> tmp;
-    t = static_cast<T>(tmp);
-    return strm;
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
--> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -536,6 +441,115 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+#define WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// OStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_ostreamable<T>: detects if T can be written to std::ostream
+template <typename T, typename = void>
+struct is_ostreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_ostreamable<
+    T,
+    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly ostreamable
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << t;
+}
+
+// Enum fallback: T is an enum without operator<<, use underlying type
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << static_cast<typename std::underlying_type<T>::type>(t);
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
+-> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+
+#ifndef WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+#define WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// IStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_istreamable<T>: detects if T can be read from std::istream
+template <typename T, typename = void>
+struct is_istreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_istreamable<
+    T,
+    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly istreamable
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_istreamable<T>::value,
+    std::istream &>::type
+{
+    return strm >> t;
+}
+
+// Enum fallback: T is an enum without operator>>, read as underlying type
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_istreamable<T>::value,
+    std::istream &>::type
+{
+    typename std::underlying_type<T>::type tmp;
+    strm >> tmp;
+    t = static_cast<T>(tmp);
+    return strm;
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
+-> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/stream-in.expected
+++ b/tests/fixtures/golden/strong-types/special-features/stream-in.expected
@@ -380,55 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// IStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_istreamable<T>: detects if T can be read from std::istream
-template <typename T, typename = void>
-struct is_istreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_istreamable<
-    T,
-    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly istreamable
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_istreamable<T>::value,
-    std::istream &>::type
-{
-    return strm >> t;
-}
-
-// Enum fallback: T is an enum without operator>>, read as underlying type
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_istreamable<T>::value,
-    std::istream &>::type
-{
-    typename std::underlying_type<T>::type tmp;
-    strm >> tmp;
-    t = static_cast<T>(tmp);
-    return strm;
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
--> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -489,6 +440,62 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+#define WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// IStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_istreamable<T>: detects if T can be read from std::istream
+template <typename T, typename = void>
+struct is_istreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_istreamable<
+    T,
+    void_t<decltype(std::declval<std::istream &>() >> std::declval<T &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly istreamable
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_istreamable<T>::value,
+    std::istream &>::type
+{
+    return strm >> t;
+}
+
+// Enum fallback: T is an enum without operator>>, read as underlying type
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_istreamable<T>::value,
+    std::istream &>::type
+{
+    typename std::underlying_type<T>::type tmp;
+    strm >> tmp;
+    t = static_cast<T>(tmp);
+    return strm;
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto istream_drill(std::istream & strm, T & t, PriorityTag<0>)
+-> decltype(istream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return istream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_4296E303C8F846C0B958EB450C57465B
 
 
 //////////////////////////////////////////////////////////////////////

--- a/tests/fixtures/golden/strong-types/special-features/stream-out.expected
+++ b/tests/fixtures/golden/strong-types/special-features/stream-out.expected
@@ -380,52 +380,6 @@ end_(T && t) noexcept(noexcept(end(std::forward<T>(t))))
     return end(std::forward<T>(t));
 }
 
-// ----------------------------------------------------------------------------
-// OStream drilling support
-// ----------------------------------------------------------------------------
-
-// is_ostreamable<T>: detects if T can be written to std::ostream
-template <typename T, typename = void>
-struct is_ostreamable
-: std::false_type
-{ };
-
-template <typename T>
-struct is_ostreamable<
-    T,
-    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
-: std::true_type
-{ };
-
-// Base case: T is directly ostreamable
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
--> typename std::enable_if<
-    is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << t;
-}
-
-// Enum fallback: T is an enum without operator<<, use underlying type
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
--> typename std::enable_if<
-    std::is_enum<T>::value &&
-    not is_ostreamable<T>::value,
-    std::ostream &>::type
-{
-    return strm << static_cast<typename std::underlying_type<T>::type>(t);
-}
-
-// Recursive case: T is an atlas type, drill down
-template <typename T>
-auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
--> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
-{
-    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
-}
-
 } // namespace atlas_detail
 
 using atlas_detail::enable_if_t;
@@ -486,6 +440,59 @@ cast(U && u)
 } // namespace atlas
 
 #endif // WJH_ATLAS_50E620B544874CB8BE4412EE6773BF90
+
+#ifndef WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+#define WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
+namespace atlas {
+namespace atlas_detail {
+// ----------------------------------------------------------------------------
+// OStream drilling support
+// ----------------------------------------------------------------------------
+
+// is_ostreamable<T>: detects if T can be written to std::ostream
+template <typename T, typename = void>
+struct is_ostreamable
+: std::false_type
+{ };
+
+template <typename T>
+struct is_ostreamable<
+    T,
+    void_t<decltype(std::declval<std::ostream &>() << std::declval<T const &>())>>
+: std::true_type
+{ };
+
+// Base case: T is directly ostreamable
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<2>)
+-> typename std::enable_if<
+    is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << t;
+}
+
+// Enum fallback: T is an enum without operator<<, use underlying type
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<1>)
+-> typename std::enable_if<
+    std::is_enum<T>::value &&
+    not is_ostreamable<T>::value,
+    std::ostream &>::type
+{
+    return strm << static_cast<typename std::underlying_type<T>::type>(t);
+}
+
+// Recursive case: T is an atlas type, drill down
+template <typename T>
+auto ostream_drill(std::ostream & strm, T const & t, PriorityTag<0>)
+-> decltype(ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{}))
+{
+    return ostream_drill(strm, atlas_value_for(t), PriorityTag<2>{});
+}
+} // namespace atlas_detail
+} // namespace atlas
+#endif // WJH_ATLAS_60461ED5AEEF4509B86FB80C8B1E0FE0
 
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Drilling down into types to support hash, istream, ostream, and format uses custom metaprogramming utilities (we should get rid of that and make it common). However, the problem happens when a project uses multiple atlas-generated files, with different levels of support.

This fixes the issue by having each one be a separate piece of code with a unique include guard (like the other optional items).